### PR TITLE
Fixed memory size error when parsing vcards

### DIFF
--- a/vCard.php
+++ b/vCard.php
@@ -573,7 +573,7 @@
 			$Parameters = array();
 			foreach ($RawParams as $Item)
 			{
-				$Parameters[] = explode('=', strtolower($Item));
+				$Parameters[] = array_filter(explode('=', strtolower($Item)));
 			}
 
 			$Type = array();
@@ -603,7 +603,7 @@
 				}
 				elseif (count($Parameter) > 2)
 				{
-					$TempTypeParams = self::ParseParameters($Key, explode(',', $RawParams[$Index]));
+				$TempTypeParams = self::ParseParameters($Key, explode(',', $RawParams[$Index]));
 					if ($TempTypeParams['type'])
 					{
 						$Type = array_merge($Type, $TempTypeParams['type']);


### PR DESCRIPTION
I recently ran into memory size errors when parsign vcards. I found a fix by adding an "array_filter" in line 576.
Also see here: http://php.net/manual/de/function.explode.php#99830